### PR TITLE
Ignore *.o files when building R package.

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^README\.Rmd$
+\.o$


### PR DESCRIPTION
Removes NOTE from devtools::check().

(_probably_ my last one, for now)